### PR TITLE
Double timeout for Ansible test commands

### DIFF
--- a/tests/sles4sap/qesapdeployment/test_system.pm
+++ b/tests/sles4sap/qesapdeployment/test_system.pm
@@ -28,7 +28,7 @@ sub run {
         'zypper in -f -y vim',
         'zypper -n in ClusterTools2'
     );
-    qesap_ansible_cmd(cmd => $_, provider => $provider_setting, timeout => 300) for @remote_cmd;
+    qesap_ansible_cmd(cmd => $_, provider => $provider_setting, timeout => 600) for @remote_cmd;
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Double timeout for Ansible test commands in qesap regression
test_system. This is needed to avoid failure in `zypper ref` when LTSS
modules are enabled.

# Verification



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Increased timeout for SAP deployment test command from 5 to 10 minutes to allow for longer execution times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->